### PR TITLE
remove default formater

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,3 @@
 {
   "deno.enable": true,
-  "editor.formatOnSave": true,
-  "[typescript]": {
-    "editor.defaultFormatter": "denoland.vscode-deno"
-  },
-  "[javascript]": {
-    "editor.defaultFormatter": "denoland.vscode-deno"
-  },
 }


### PR DESCRIPTION
cc @youngjuning 

我移除了默认的格式化设置，因为用户可能没有安装 vscode 插件。（PS：当前插件的格式化工具还有些问题）